### PR TITLE
Multiorgan dev v1 002

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ tb_logs/
 /data/data_config.py
 __pycache__/
 /experiments/
+/adpkd_segmentation/inference/test/
 *.csv

--- a/adpkd_segmentation/inference/add_ensemble.py
+++ b/adpkd_segmentation/inference/add_ensemble.py
@@ -1,0 +1,69 @@
+import json
+from argparse import ArgumentParser
+import os
+from pathlib import Path
+
+from inference import run_inference
+
+
+# Preliminary Data
+print("Loading system and pipeline configuration...")
+id_system = open("adpkd_segmentation/inference/ensemble_config.json", "r")
+system_config = json.loads(id_system.read())
+# Parser Setup
+parser = ArgumentParser()
+parser.add_argument(
+    "-i",
+    "--inference_path",
+    type=str,
+    help="path to input dicom data (replaces path in config file)",
+    default=None,
+)
+
+parser.add_argument(
+    "-o",
+    "--output_path",
+    type=str,
+    help="path to output location",
+    default=None,
+)
+
+
+def run_addition_ensemble(input_path=None, output_path=None):
+    # Individual Organ inference
+    pred_load_dir = []
+    for idx_organ, name_organ in enumerate(system_config["organ_name"]):
+        print(
+            "Run " + str(idx_organ + 1) + ": " + name_organ + " inference...\n"
+        )
+        save_path = os.path.join(output_path, name_organ)
+        config_path = system_config["model_dir"]["T2"]["Axial"][idx_organ]
+        saved_inference = Path(save_path) / system_config["svd_inf"]
+        saved_figs = Path(save_path) / system_config["svd_figs"]
+        run_inference(
+            config_path=config_path,
+            inference_path=input_path,
+            saved_inference=saved_inference,
+            saved_figs=saved_figs,
+        )  # Test this tomorrow
+        pred_load_dir.append(save_path)
+        print(system_config["organ_name"][idx_organ] + " inference complete")
+        #
+        # Addition Ensemble -- Add in v1.02
+
+    # Save the output -- Add in v1.02 or v1.03
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    inference_path = args.inference_path
+    output_path = args.output_path
+    # Prep the output path
+    if inference_path is not None:
+        inf_path = inference_path
+
+    if output_path is not None:
+        out_path = output_path
+
+    run_addition_ensemble(input_path=inf_path, output_path=out_path)

--- a/adpkd_segmentation/inference/add_ensemble.py
+++ b/adpkd_segmentation/inference/add_ensemble.py
@@ -8,11 +8,6 @@ from inference import run_inference
 from ensemble_utils import get_scan, addition_ensemble
 
 
-# Preliminary Data
-print("Loading system and pipeline configuration...")
-config_path = "adpkd_segmentation/inference/ensemble_config.json"
-with open(config_path, "r") as id_system:
-    system_config = json.loads(id_system.read())
 # Parser Setup
 parser = ArgumentParser()
 parser.add_argument(
@@ -31,8 +26,24 @@ parser.add_argument(
     default=None,
 )
 
+parser.add_argument(
+    "-c",
+    "--config_path",
+    type=str,
+    help="Path that points to the desired configuration file",
+    default="adpkd_segmentation/inference/ensemble_config.json",
+)
 
-def run_addition_ensemble(input_path=None, output_path=None):
+
+def run_addition_ensemble(
+    input_path=None,
+    output_path=None,
+    config_path=None,
+):
+    # Preliminary Data
+    print("Loading system and pipeline configuration...")
+    with open(config_path, "r") as id_system:
+        system_config = json.loads(id_system.read())
     # Individual Organ inference
     pred_load_dir = []
     for idx_organ, name_organ in enumerate(system_config["organ_name"]):
@@ -95,6 +106,7 @@ if __name__ == "__main__":
 
     inference_path = args.inference_path
     output_path = args.output_path
+    config_path = "adpkd_segmentation/inference/ensemble_config.json"
     # Prep the output path
     if inference_path is not None:
         inf_path = inference_path
@@ -102,4 +114,6 @@ if __name__ == "__main__":
     if output_path is not None:
         out_path = output_path
 
-    run_addition_ensemble(input_path=inf_path, output_path=out_path)
+    run_addition_ensemble(
+        input_path=inf_path, output_path=out_path, config_path=config_path
+    )

--- a/adpkd_segmentation/inference/add_ensemble.py
+++ b/adpkd_segmentation/inference/add_ensemble.py
@@ -2,14 +2,17 @@ import json
 from argparse import ArgumentParser
 import os
 from pathlib import Path
+import nibabel as nib
 
 from inference import run_inference
+from ensemble_utils import get_scan, addition_ensemble
 
 
 # Preliminary Data
 print("Loading system and pipeline configuration...")
-id_system = open("adpkd_segmentation/inference/ensemble_config.json", "r")
-system_config = json.loads(id_system.read())
+config_path = "adpkd_segmentation/inference/ensemble_config.json"
+with open(config_path, "r") as id_system:
+    system_config = json.loads(id_system.read())
 # Parser Setup
 parser = ArgumentParser()
 parser.add_argument(
@@ -45,13 +48,46 @@ def run_addition_ensemble(input_path=None, output_path=None):
             inference_path=input_path,
             saved_inference=saved_inference,
             saved_figs=saved_figs,
-        )  # Test this tomorrow
-        pred_load_dir.append(save_path)
-        print(system_config["organ_name"][idx_organ] + " inference complete")
+        )
+        pred_load_dir.append(Path(save_path))
+        print(name_organ + " inference complete")
         #
-        # Addition Ensemble -- Add in v1.02
+    # Create ensemble save path
+    temp_name = ""
+    if len(system_config["organ_name"]) <= system_config["max_organ_title"]:
+        for name in system_config["organ_name"]:
+            temp_name += f"_{name}"
+    else:
+        temp_name = "_organs"
+    combined_folder_name = f"Addition_Ensemble{temp_name}"
+    combine_path = Path(output_path) / combined_folder_name
+    # Addition Ensemble
+    print("Combining the organ segmentations...")
+    scan_list = list(pred_load_dir[0].glob(f'**/*{system_config["pred_vol"]}'))
+    for idScn, scan in enumerate(scan_list):
+        temp_dict = {"organ_paths": pred_load_dir, "idS": idScn}
+        scan_folder = get_scan(system_config, scan)
+        print(f"Combining for scan {scan_folder}")
+        comb_mask = addition_ensemble(temp_dict, system_config)
 
-    # Save the output -- Add in v1.02 or v1.03
+        # Save the output
+        save_path = combine_path / scan_folder
+        save_path.mkdir(parents=True, exist_ok=True)
+        #
+        dicom_parent, _ = os.path.split(scan)
+        dicom_nii_dir = Path(dicom_parent) / system_config["dicom_vol"]
+        mri_nifti = nib.load(dicom_nii_dir)
+        nifti_affine = mri_nifti.affine
+        nifti_header = mri_nifti.header.copy()
+        combined_pred_vol = nib.Nifti1Image(
+            comb_mask, affine=nifti_affine, header=nifti_header
+        )
+        print("Saving...")
+        nib.save(mri_nifti, save_path / system_config["dicom_vol"])
+        nib.save(
+            combined_pred_vol,
+            save_path / system_config["combined_pred_filename"],
+        )
 
 
 if __name__ == "__main__":

--- a/adpkd_segmentation/inference/ensemble_config.json
+++ b/adpkd_segmentation/inference/ensemble_config.json
@@ -1,0 +1,71 @@
+{
+    "group": "",
+    "max_organ_title": 4,
+    "mode": "ensemble addition",
+    "svd_inf": "saved_inference",
+    "svd_figs": "saved_figs",
+    "youngest_child": "ITKSNAP_DCM_NIFTI",
+    "dicom_ext": ".dcm",
+    "pred_vol": "pred_vol.nii",
+    "dicom_vol": "dicom_vol.nii",
+    "combined_folder": "multiorgan_ensemble",
+    "combined_pred_filename": "comb_pred_vol.nii",
+    "add_organ_color": [
+        2,
+        4,
+        8
+    ],
+    "add_overlap": [
+        6,
+        10,
+        12,
+        14
+    ],
+    "overlap_recolor": [
+        1,
+        2,
+        8,
+        8
+    ],
+    "repaint_side": [
+        "right",
+        "all"
+    ],
+    "orig_color": [
+        2,
+        8
+    ],
+    "view_color": [
+        1,
+        3
+    ],
+    "sitk_obj_rl_dim": 0,
+    "organ_name": [
+        "kidney",
+        "liver",
+        "spleen"
+    ],
+    "model_name": [
+        "adpkd",
+        "liver",
+        "spleen"
+    ],
+    "recolor_spleen": [
+        8,
+        3
+    ],
+    "inference_ensemble_color": [
+        2,
+        4,
+        3
+    ],
+    "model_dir": {
+        "T2": {
+            "Axial": [
+                "checkpoints/kidney_model.yml",
+                "checkpoints/liver_model.yml",
+                "checkpoints/spleen_model.yml"
+            ]
+        }
+    }
+}

--- a/adpkd_segmentation/inference/ensemble_utils.py
+++ b/adpkd_segmentation/inference/ensemble_utils.py
@@ -1,0 +1,2 @@
+import glob
+import os

--- a/adpkd_segmentation/inference/ensemble_utils.py
+++ b/adpkd_segmentation/inference/ensemble_utils.py
@@ -85,6 +85,6 @@ def addition_ensemble(iter_dict, config):
     overlap_mask = mask_add(iter_dict, config)
     return overlap_mask  # For testing purposes -- v1_002 only
     # Coming soon -- v1_003
-    # process_org_color_mask = overlap_repaint(overlap_mask,config,other_args...)
+    # intermediate_mask = overlap_repaint(overlap_mask,config,other_args...)
     # comb_mask = organ_repaint(process_org_color_mask,config)
     # return comb_mask

--- a/adpkd_segmentation/inference/ensemble_utils.py
+++ b/adpkd_segmentation/inference/ensemble_utils.py
@@ -1,2 +1,90 @@
-import glob
 import os
+from pathlib import Path
+import nibabel as nib
+import numpy as np
+
+
+def get_tail(dir=".", depth=1):
+    """
+    Given a folder path OR directory, return
+    the folder given the depth.
+    Note: depth = 1 denotes the newest folder
+    in the tree.
+    """
+    t_head = dir
+    num_depth = depth
+    if os.path.isfile(dir):
+        num_depth += 1
+    #
+    idx = 0
+    while idx < num_depth:  # test
+        t_head, t_tail = os.path.split(t_head)
+        idx += 1
+    #
+    return t_tail  # Tested, good
+
+
+def get_scan(config, dir="."):
+    """This is designed for the output folder pattern in
+    ADPKD-segmentation-pytorch (Goel et al. Radiology AI). At inference, the
+    nifti files are saved in
+    .../saved_inference/repo_name/patient_ID/scan_folder/ITKSNAP_DCM_NIFTI/pred.vol.nii
+    You can find Dr. Goel's repo at:
+    https://github.com/aksg87/adpkd-segmentation-pytorch.git
+    And you can find his deployment:
+    web: https://pubs.rsna.org/doi/10.1148/ryai.210205
+    doi: https://doi.org/10.1148/ryai.210205
+    """
+    target_depth = 1
+    if get_tail(dir, target_depth) == config["youngest_child"]:
+        target_depth += 1
+    return get_tail(dir, target_depth)
+
+
+def grab_organ_dirs(iter_dict, config):
+    """Given the initial parent path,
+    we will provide the directories to
+    all files + scans"""
+    path_dict = {}
+    if config["mode"] == "ensemble addition":
+        for organ, organ_path in zip(
+            config["organ_name"], iter_dict["organ_paths"]
+        ):
+            path_dict[organ] = list(
+                Path(organ_path).glob(f"**/*{config['pred_vol']}")
+            )
+        return path_dict  # TEST THIS
+    # To Do: if config['mode'] = "ensemble softmax"
+
+
+def mask_add(iter_dict, config):
+    idScan = iter_dict["idS"]  # Scan index
+    for idO, organ, add_color in zip(
+        range(len(config["organ_name"])),
+        config["organ_name"],
+        config["add_organ_color"],
+    ):
+        load_dir = iter_dict["mask_directories"][organ][idScan]
+        tmp_nii = nib.load(load_dir)
+        tmp_arr = np.array(tmp_nii.dataobj)
+        if idO == 0:
+            temp_combine = np.zeros(np.shape(tmp_arr))
+        temp_combine += add_color * tmp_arr
+
+    return np.uint16(temp_combine)
+
+
+def addition_ensemble(iter_dict, config):
+    """Given a dictionary that temporarily holds
+    the organ paths and scan index,"""
+    # Current commit: finalize mask_add
+    # Next commit:
+    #   -overlap_repaint
+    #   -organ_repaint
+    iter_dict["mask_directories"] = grab_organ_dirs(iter_dict, config)
+    overlap_mask = mask_add(iter_dict, config)
+    return overlap_mask  # For testing purposes -- v1_002 only
+    # Coming soon -- v1_003
+    # process_org_color_mask = overlap_repaint(overlap_mask,config,other_args...)
+    # comb_mask = organ_repaint(process_org_color_mask,config)
+    # return comb_mask


### PR DESCRIPTION
Hello Everyone. In this commit I have a basic implementation of the addition ensemble, as used in the paper. I will give a quick rundown of the file changes made in this commit:

**adpkd_segmentation/inference/add_ensemble.py**
    - Calls the `addition_ensemble()` function from the `ensemble_utilities` module
    - At this point, I am happy with this script for the most part, contingent on some minor improvements in the next PR
    - I will add a readme in the next PR, or in the PR after.
    
**adpkd_segmentation/inference/ensemble_utils.py**
    - Created some path utilities related to Dr. Goel's inference file structure `get_tail(), get_scan()`
    - Refactored the code with `grab_organ_dirs()`. I now glob the output directory once -- by putting the list of scans into its 
       organ key pair. 
        - In the next commit, I think I will move `iter_dict["mask_directories"]= grab_organ_dirs()' to my main script
        - the call will be just before the "scan" loop, so that I don't have to recursive glob the output path each time.
    - `mask_add()` also leverages the existing organ names as keys holding the respective scan pointers for each directory.
    - `addition_ensemble()` only performs the basic addition, but I have included an outline of the following sections in the next 
       commit.

I will send over the testing path via Trello + slack.

-Dom